### PR TITLE
Add kernel dimension as parameter to conv-types

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ height = 4
 width = 4
 
 function model(nconv)
-    invertex = inputvertex("in", 1, FluxConv())
+    invertex = inputvertex("in", 1, FluxConv{2}())
     l = invertex
     for i in 1:nconv
         l = conv(l, 16, relu)

--- a/src/types.jl
+++ b/src/types.jl
@@ -17,13 +17,13 @@ layertype(l::Flux.Recur{<:Flux.RNNCell}) = FluxRnn()
 layertype(l::Flux.Recur{<:Flux.LSTMCell}) = FluxLstm()
 layertype(l::Flux.Recur{<:Flux.GRUCell}) = FluxGru()
 
-abstract type FluxConvolutional <: FluxParLayer end
-struct FluxConv <: FluxConvolutional end
-struct FluxConvTranspose  <: FluxConvolutional end
-struct FluxDepthwiseConv <: FluxConvolutional  end
-layertype(l::Conv) = FluxConv()
-layertype(l::ConvTranspose) = FluxConvTranspose()
-layertype(l::DepthwiseConv) = FluxDepthwiseConv()
+abstract type FluxConvolutional{N} <: FluxParLayer end
+struct FluxConv{N} <: FluxConvolutional{N} end
+struct FluxConvTranspose{N}  <: FluxConvolutional{N} end
+struct FluxDepthwiseConv{N} <: FluxConvolutional{N}  end
+layertype(l::Conv{N}) where N = FluxConv{N}()
+layertype(l::ConvTranspose{N}) where N = FluxConvTranspose{N}()
+layertype(l::DepthwiseConv{N}) where N = FluxDepthwiseConv{N}()
 
 
 abstract type FluxTransparentLayer <: FluxLayer end

--- a/src/util.jl
+++ b/src/util.jl
@@ -53,12 +53,12 @@ outdim(::FluxRecurrent) = 1
 actdim(::FluxRecurrent) = 1
 actrank(::FluxRecurrent) = 2
 
-indim(::FluxConvolutional) = 4
-outdim(::FluxConvolutional) = 3
-actdim(::FluxConvolutional) = 3
-actrank(::FluxConvolutional) = 3
-indim(::FluxConv) = 3
-outdim(::FluxConv) = 4
+indim(::FluxConvolutional{N}) where N = 2+N
+outdim(::FluxConvolutional{N}) where N = 1+N
+actdim(::FluxConvolutional{N}) where N = 1+N
+actrank(::FluxConvolutional{N}) where N = 1+N
+indim(::FluxConv{N}) where N = 1+N
+outdim(::FluxConv{N}) where N = 2+N
 
 # Note: Contrary to other ML frameworks, bias seems to always be present in Flux
 weights(l) = weights(layertype(l), l)

--- a/src/vertex.jl
+++ b/src/vertex.jl
@@ -17,6 +17,7 @@ NaiveNASlib.inputvertex(name, size, type::FluxLayer) = InputShapeVertex(inputver
 layertype(v::InputShapeVertex) = v.t
 layer(v::InputShapeVertex) = LayerTypeWrapper(v.t)
 NaiveNASlib.base(v::InputShapeVertex) = v.base
+NaiveNASlib.name(v::InputShapeVertex) = name(base(v))
 NaiveNASlib.nout(v::InputShapeVertex) = nout(base(v))
 NaiveNASlib.nin(v::InputShapeVertex) = nin(base(v))
 NaiveNASlib.outputs(v::InputShapeVertex) = outputs(base(v))

--- a/test/examples.jl
+++ b/test/examples.jl
@@ -76,7 +76,7 @@
         width = 4
 
         function model(nconv)
-            invertex = inputvertex("in", 1, FluxConv())
+            invertex = inputvertex("in", 1, FluxConv{2}())
             l = invertex
             for i in 1:nconv
                 l = conv(l, 16, relu)

--- a/test/util.jl
+++ b/test/util.jl
@@ -10,14 +10,26 @@ using Flux
         @test nin(Dense(3,4)) == 3
         @test nout(Dense(3,4)) == 4
 
+        @test nin(Conv((2,), 3=>4)) == 3
+        @test nout(Conv((2,), 3=>4)) == 4
         @test nin(Conv((1,2), 3=>6)) == 3
         @test nout(Conv((1,2), 3=>6)) == 6
+        @test nin(Conv((1,2,3), 4=>5)) == 4
+        @test nout(Conv((1,2,3), 4=>5)) == 5
 
+        @test nin(ConvTranspose((2,), 3=>4)) == 3
+        @test nout(ConvTranspose((2,), 3=>4)) == 4
         @test nin(ConvTranspose((1,2), 3=>6)) == 3
         @test nout(ConvTranspose((1,2), 3=>6)) == 6
+        @test nin(ConvTranspose((1,2,3), 4=>5)) == 4
+        @test nout(ConvTranspose((1,2,3), 4=>5)) == 5
 
+        @test nin(DepthwiseConv((2,), 3=>4)) == 3
+        @test nout(DepthwiseConv((2,), 3=>4)) == 4
         @test nin(DepthwiseConv((1,2), 3=>6)) == 3
         @test nout(DepthwiseConv((1,2), 3=>6)) == 6
+        @test nin(DepthwiseConv((1,2,3), 4=>5)) == 4
+        @test nout(DepthwiseConv((1,2,3), 4=>5)) == 5
 
         @test nin(Flux.Diagonal(3)) == nout(Flux.Diagonal(3)) == 3
 

--- a/test/vertex.jl
+++ b/test/vertex.jl
@@ -18,7 +18,7 @@ using Flux
         @test outputs(dense1) == [dense2]
         @test inputs(dense1) == [inpt]
         @test outputs(inpt) == [dense1]
-        
+
         @test layer(dense1) == dl1
         @test layer(dense2) == dl2
         @test layertype(dense1) == FluxDense()
@@ -147,8 +147,8 @@ using Flux
             nin2 = 7
             indata1 = reshape(collect(Float32, 1:nin1*4*4), 4, 4, nin1, 1)
             indata2 = reshape(collect(Float32, 1:nin2*4*4), 4, 4, nin2, 1)
-            in1 = inputvertex("in1", nin1, FluxConv())
-            in2 = inputvertex("in2", nin2, FluxConv())
+            in1 = inputvertex("in1", nin1, FluxConv{2}())
+            in2 = inputvertex("in2", nin2, FluxConv{2}())
             vfun(v,s) = mutable(BatchNorm(nout(v)), v)
 
             @test size(testgraph_vfun(vfun, in1, in2)(indata1, indata2)) == (4,4,10,1)

--- a/test/vertex.jl
+++ b/test/vertex.jl
@@ -1,7 +1,12 @@
 using NaiveNASflux
 import NaiveNASflux: weights, bias
-using NaiveNASlib
-using Flux
+
+@testset "InputShapeVertex" begin
+    v = inputvertex("in", 3, FluxDense())
+    @test layertype(v) == FluxDense()
+    @test name(v) == "in"
+    @test nout(v) == 3
+end
 
 @testset "Size mutations" begin
 


### PR DESCRIPTION
Use kernel dimension to determine indim/outdim/actdim for conv-types
Fix #7