### PR TITLE
Add option to compute activation contribution every N batches

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NaiveNASflux"
 uuid = "85610aed-7d32-5e57-bb50-4c2e1c9e7997"
-version = "1.3.0"
+version = "1.4.0"
 
 [deps]
 Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"

--- a/src/NaiveNASflux.jl
+++ b/src/NaiveNASflux.jl
@@ -16,7 +16,7 @@ export mutable, concat, AbstractMutableComp, MutableLayer, LazyMutable, NoParams
 
 export named, validated, logged
 
-export ActivationContribution, neuron_value, NeuronValueTaylor, Ewma, NeuronValueEvery
+export ActivationContribution, neuron_value, neuronvaluetaylor, Ewma, NeuronValueEvery
 
 export indim, outdim, actdim, layer, layertype
 

--- a/src/NaiveNASflux.jl
+++ b/src/NaiveNASflux.jl
@@ -16,7 +16,7 @@ export mutable, concat, AbstractMutableComp, MutableLayer, LazyMutable, NoParams
 
 export named, validated, logged
 
-export ActivationContribution, neuron_value, Ewma
+export ActivationContribution, neuron_value, NeuronValueTaylor, Ewma, NeuronValueEvery
 
 export indim, outdim, actdim, layer, layertype
 

--- a/src/pruning.jl
+++ b/src/pruning.jl
@@ -63,6 +63,9 @@ neuron_value(l) = neuron_value(layertype(l), l)
 # Maybe do something about state in recurrent layers as well, but CBA to do it right now
 neuron_value(::FluxParLayer, l) = mean_squeeze(abs.(weights(l)), outdim(l)) + abs.(bias(l))
 
+# Not possible to do anything since we don't know the size. Implementors can however use this to fallback to other ways if this is not an error
+neuron_value(lt, l) = missing
+
 """
     neuronvaluetaylor(currval, act, grad)
 

--- a/src/pruning.jl
+++ b/src/pruning.jl
@@ -46,8 +46,8 @@ end
 
 Return mean value of `x` along all dimensions except `dimkeep` as a 1D array (singleton dimensions are removed).
 """
-function mean_squeeze(x, dimkeep)
-    dims = filter(i -> i != dimkeep, 1:ndims(x))
+function mean_squeeze(x, dimskeep)
+    dims = filter(i -> i ∉ dimskeep, 1:ndims(x))
     return dropdims(mean(x, dims=dims), dims=Tuple(dims))
 end
 
@@ -73,7 +73,7 @@ Calculate contribution of activations towards loss according to https://arxiv.or
 
 Short summary is that the first order taylor approximation of the optimization problem: "which neurons shall I remove to minimize impact on the loss function?" boils down to: "the ones which minimize abs(gradient * activation)" (assuming parameter independence).
 """
-neuronvaluetaylor(currval, act, grad) = mean_squeeze(abs.(act .* grad), actdim(ndims(act)))
+neuronvaluetaylor(currval, act, grad) = mean_squeeze(abs.(mean_squeeze(act .* grad, (actdim(ndims(act)), ndims(act)))), 1)
 
 
 """

--- a/src/pruning.jl
+++ b/src/pruning.jl
@@ -11,11 +11,11 @@ Can be a performance bottleneck in cases with large activations. Use [`NeuronVal
 """
 mutable struct ActivationContribution{L,M} <: AbstractMutableComp
     layer::L
-    contribution # Just because I CBA to guess type in case of missing :(
+    contribution::Union{Missing, Vector{<:Real}} # Type of activation not known yet :(
     method::M
 end
-ActivationContribution(l::AbstractMutableComp) = ActivationContribution(l, zeros(Float32, nout(l)), Ewma(0.05))
-ActivationContribution(l) = ActivationContribution(l, missing, Ewma(0.05))
+ActivationContribution(l::AbstractMutableComp, method = Ewma(0.05, neuronvaluetaylor)) = ActivationContribution(l, zeros(Float32, nout(l)), method)
+ActivationContribution(l, method = Ewma(0.05, neuronvaluetaylor)) = ActivationContribution(l, missing, method)
 
 layer(m::ActivationContribution) = layer(m.layer)
 layertype(m::ActivationContribution) = layertype(m.layer)

--- a/src/pruning.jl
+++ b/src/pruning.jl
@@ -93,8 +93,12 @@ struct Ewma{R<:Real, M}
 end
 Ewma(α) = Ewma(α, NeuronValueTaylor())
 
-calc_neuron_value(m::Ewma, currval, act, grad) = m.α .* cpu(currval) .+ (1 - m.α) .* cpu(calc_neuron_value(m.method, currval, act, grad))
-calc_neuron_value(m::Ewma, ::Missing, act, grad) = cpu(calc_neuron_value(m.method, missing, act, grad))
+calc_neuron_value(m::Ewma, currval, act, grad) = agg(m, currval, calc_neuron_value(m.method, currval, act, grad))
+
+# Basically for backwards compatibility even though method is not exported
+agg(m::Ewma, x, y) = m.α .* cpu(x) .+ (1 - m.α) .* cpu(y)
+agg(m::Ewma, ::Missing, y) = cpu(y)
+
 
 """
     NeuronValueEvery{N,T}

--- a/src/pruning.jl
+++ b/src/pruning.jl
@@ -14,8 +14,8 @@ mutable struct ActivationContribution{L,M} <: AbstractMutableComp
     contribution # Type of activation not known yet :( Also leave some room for experimenting with things like storing the metric on the GPU
     method::M
 end
-ActivationContribution(l::AbstractMutableComp, method = Ewma(0.05, neuronvaluetaylor)) = ActivationContribution(l, zeros(Float32, nout(l)), method)
-ActivationContribution(l, method = Ewma(0.05, neuronvaluetaylor)) = ActivationContribution(l, missing, method)
+ActivationContribution(l::AbstractMutableComp, method = Ewma(0.05)) = ActivationContribution(l, zeros(Float32, nout(l)), method)
+ActivationContribution(l, method = Ewma(0.05)) = ActivationContribution(l, missing, method)
 
 layer(m::ActivationContribution) = layer(m.layer)
 layertype(m::ActivationContribution) = layertype(m.layer)

--- a/src/pruning.jl
+++ b/src/pruning.jl
@@ -11,7 +11,7 @@ Can be a performance bottleneck in cases with large activations. Use [`NeuronVal
 """
 mutable struct ActivationContribution{L,M} <: AbstractMutableComp
     layer::L
-    contribution::Union{Missing, Vector{<:Real}} # Type of activation not known yet :(
+    contribution # Type of activation not known yet :( Also leave some room for experimenting with things like storing the metric on the GPU
     method::M
 end
 ActivationContribution(l::AbstractMutableComp, method = Ewma(0.05, neuronvaluetaylor)) = ActivationContribution(l, zeros(Float32, nout(l)), method)

--- a/src/pruning.jl
+++ b/src/pruning.jl
@@ -1,14 +1,18 @@
 """
- Calculate contribution of activations towards loss according to https://arxiv.org/abs/1611.06440.
+    ActivationContribution{L,M} <: AbstractMutableComp
+    ActivationContribution(l)
+    ActivationContribution(l, method)
+
+Calculate neuron value based on activations and gradients using `method` (default EWMA of [`NeuronValueTaylor`](@ref)).
 
 High value of `contribution` means that the neuron of that index has a high contribution to the loss score.
 
-Short summary is that the first order taylor approximation of the optimization problem: "which neurons shall I remove to minimize impact on the loss function" boils down to: "the ones which minimize abs(gradient * activation)" (assuming parameter independence).
+Can be a performance bottleneck in cases with large activations. Use [`NeuronValueEvery`](@ref) to mitigate.
 """
-mutable struct ActivationContribution <: AbstractMutableComp
-    layer
-    contribution
-    aggmethod
+mutable struct ActivationContribution{L,M} <: AbstractMutableComp
+    layer::L
+    contribution # Just because I CBA to guess type in case of missing :(
+    method::M
 end
 ActivationContribution(l::AbstractMutableComp) = ActivationContribution(l, zeros(Float32, nout(l)), Ewma(0.05))
 ActivationContribution(l) = ActivationContribution(l, missing, Ewma(0.05))
@@ -18,14 +22,14 @@ layertype(m::ActivationContribution) = layertype(m.layer)
 wrapped(m::ActivationContribution) = m.layer
 NaiveNASlib.minΔninfactor(m::ActivationContribution) = minΔninfactor(wrapped(m))
 NaiveNASlib.minΔnoutfactor(m::ActivationContribution) = minΔnoutfactor(wrapped(m))
-functor_fields(T::Type{ActivationContribution}) = (:layer,)
+functor_fields(::Type{ActivationContribution}) = (:layer,)
 
 function(m::ActivationContribution)(x...)
     act = wrapped(m)(x...)
 
     return hook(act) do grad
-        grad == nothing && return grad
-        m.contribution = agg(m.aggmethod, m.contribution, mean_squeeze(abs.(act .* grad), actdim(ndims(act))))
+        grad === nothing && return grad
+        m.contribution = calc_neuron_value(m.method, m.contribution, act, grad)
         return grad
     end
 end
@@ -57,21 +61,58 @@ neuron_value(l) = neuron_value(layertype(l), l)
 
 # Default: highest mean of abs of weights + bias. Not a very good metric, but should be better than random
 # Maybe do something about state in recurrent layers as well, but CBA to do it right now
-neuron_value(t::FluxParLayer, l) = mean_squeeze(abs.(weights(l)), outdim(l)) + abs.(bias(l))
+neuron_value(::FluxParLayer, l) = mean_squeeze(abs.(weights(l)), outdim(l)) + abs.(bias(l))
 
 """
-    Ewma(α::Real)
+    NeuronValueTaylor
 
-Exponential moving average.
+Calculate contribution of activations towards loss according to https://arxiv.org/abs/1611.06440.
+
+Short summary is that the first order taylor approximation of the optimization problem: "which neurons shall I remove to minimize impact on the loss function?" boils down to: "the ones which minimize abs(gradient * activation)" (assuming parameter independence).
+"""
+struct NeuronValueTaylor end
+
+calc_neuron_value(::NeuronValueTaylor, currval, act, grad) = mean_squeeze(abs.(act .* grad), actdim(ndims(act)))
+
+
+"""
+    Ewma{R<:Real, M}
+    Ewma(α::Real, method)
+
+Exponential moving average of neuron value calculated by `method`.
 
 Parameter `α` acts as a forgetting factor, i.e larger values means faster convergence but more noisy estimate.
 """
-struct Ewma
-    α
-    function Ewma(α::Real)
+struct Ewma{R<:Real, M}
+    α::R
+    method::M
+    function Ewma(α::R, method::M) where {R,M}
         0 <= α <= 1 || error("α must be between 0 and 1, was $α")
-        new(α)
+        new{R,M}(α, method)
     end
 end
-agg(m::Ewma, x, y) = m.α .* cpu(x) .+ (1 - m.α) .* cpu(y)
-agg(m::Ewma, ::Missing, y) = cpu(y)
+Ewma(α) = Ewma(α, NeuronValueTaylor())
+
+calc_neuron_value(m::Ewma, currval, act, grad) = m.α .* cpu(currval) .+ (1 - m.α) .* cpu(calc_neuron_value(m.method, currval, act, grad))
+calc_neuron_value(m::Ewma, ::Missing, act, grad) = cpu(calc_neuron_value(m.method, missing, act, grad))
+
+"""
+    NeuronValueEvery{N,T}
+    NeuronValueEvery(n::Int, method::T)
+
+Calculate neuron value using `method` every `n`:th call.
+
+Useful to reduce runtime overhead.
+"""
+mutable struct NeuronValueEvery{N,T}
+    cnt::Int
+    method::T
+    NeuronValueEvery(N::Int, method::T) where T = new{N, T}(0, method)
+end
+NeuronValueEvery(n::Int) = NeuronValueEvery(n, Ewma(0.05))
+
+function calc_neuron_value(m::NeuronValueEvery{N}, currval, act, grad) where N
+    ret = m.cnt % N == 0 ? calc_neuron_value(m.method, currval, act, grad) : currval
+    m.cnt += 1
+    return ret
+end

--- a/test/pruning.jl
+++ b/test/pruning.jl
@@ -77,6 +77,23 @@
         @test length(params(l)) == length(params(layer(l)))
     end
 
+    @testset "Neuron value Dense act contrib every 4" begin
+        l = ml(Dense(3,5), l -> ActivationContribution(l, NeuronValueEvery(4)))
+        @test neuron_value(l) == zeros(5)
+        nvprev = copy(neuron_value(l))
+        tr(l, ones(Float32, 3, 4))
+        @test neuron_value(l) != nvprev
+        nvprev = copy(neuron_value(l))
+
+        tr(l, ones(Float32, 3, 4))
+        @test nvprev == neuron_value(l)
+
+        tr(l, ones(Float32, 3, 4))
+        tr(l, ones(Float32, 3, 4))
+        tr(l, ones(Float32, 3, 4))
+        @test nvprev != neuron_value(l)
+    end
+
     @testset "Neuron value RNN act contrib" begin
         l = ml(RNN(3,5), ActivationContribution)
         @test neuron_value(l) == zeros(5)

--- a/test/pruning.jl
+++ b/test/pruning.jl
@@ -17,27 +17,25 @@
 
 
     @testset "Utils" begin
-        import NaiveNASflux:calc_neuron_value
-        actonly = () -> ()
-        NaiveNASflux.calc_neuron_value(::typeof(actonly), cv, act, grad) = act
+        actonly(curr, act, grad) = act
 
         @testset "Ewma" begin
             m = Ewma(0.3, actonly)
-            @test calc_neuron_value(m, missing, [1,2,3,4], :ignored) == [1,2,3,4]
-            @test calc_neuron_value(m, [1,2,3,4], [5,6,7,8], :ignored) ≈ [3.8, 4.8, 5.8, 6.8]
+            @test m(missing, [1,2,3,4], :ignored) == [1,2,3,4]
+            @test m([1,2,3,4], [5,6,7,8], :ignored) ≈ [3.8, 4.8, 5.8, 6.8]
         end
 
         @testset "NeuronValueEvery{3}" begin
             m = NeuronValueEvery(3, actonly)
-            @test calc_neuron_value(m, :old, :new, :ignored) == :new
-            @test calc_neuron_value(m, :old, :new, :ignored) == :old
-            @test calc_neuron_value(m, :old, :new, :ignored) == :old
-            @test calc_neuron_value(m, :old, :new, :ignored) == :new
-            @test calc_neuron_value(m, :old, :new, :ignored) == :old
-            @test calc_neuron_value(m, :old, :new, :ignored) == :old
-            @test calc_neuron_value(m, :old, :new, :ignored) == :new
-            @test calc_neuron_value(m, :old, :new, :ignored) == :old
-            @test calc_neuron_value(m, :old, :new, :ignored) == :old
+            @test m(:old, :new, :ignored) == :new
+            @test m(:old, :new, :ignored) == :old
+            @test m(:old, :new, :ignored) == :old
+            @test m(:old, :new, :ignored) == :new
+            @test m(:old, :new, :ignored) == :old
+            @test m(:old, :new, :ignored) == :old
+            @test m(:old, :new, :ignored) == :new
+            @test m(:old, :new, :ignored) == :old
+            @test m(:old, :new, :ignored) == :old
         end
     end
 

--- a/test/pruning.jl
+++ b/test/pruning.jl
@@ -15,11 +15,30 @@
         Flux.train!((x,y) -> Flux.mse(l(x...), y), params(l), example, Descent(0.1))
     end
 
-    @testset "Ewma" begin
-        import NaiveNASflux:agg
-        m = Ewma(0.3)
-        @test agg(m, missing, [1,2,3,4]) == [1,2,3,4]
-        @test agg(m, [1,2,3,4], [5,6,7,8]) ≈ [3.8, 4.8, 5.8, 6.8]
+
+    @testset "Utils" begin
+        import NaiveNASflux:calc_neuron_value
+        actonly = () -> ()
+        NaiveNASflux.calc_neuron_value(::typeof(actonly), cv, act, grad) = act
+
+        @testset "Ewma" begin
+            m = Ewma(0.3, actonly)
+            @test calc_neuron_value(m, missing, [1,2,3,4], :ignored) == [1,2,3,4]
+            @test calc_neuron_value(m, [1,2,3,4], [5,6,7,8], :ignored) ≈ [3.8, 4.8, 5.8, 6.8]
+        end
+
+        @testset "NeuronValueEvery{3}" begin
+            m = NeuronValueEvery(3, actonly)
+            @test calc_neuron_value(m, :old, :new, :ignored) == :new
+            @test calc_neuron_value(m, :old, :new, :ignored) == :old
+            @test calc_neuron_value(m, :old, :new, :ignored) == :old
+            @test calc_neuron_value(m, :old, :new, :ignored) == :new
+            @test calc_neuron_value(m, :old, :new, :ignored) == :old
+            @test calc_neuron_value(m, :old, :new, :ignored) == :old
+            @test calc_neuron_value(m, :old, :new, :ignored) == :new
+            @test calc_neuron_value(m, :old, :new, :ignored) == :old
+            @test calc_neuron_value(m, :old, :new, :ignored) == :old
+        end
     end
 
     @testset "Neuron value Dense default" begin

--- a/test/pruning.jl
+++ b/test/pruning.jl
@@ -54,6 +54,11 @@
         @test size(neuron_value(l)) == (5,)
     end
 
+    @testset "Neuron value unkown default" begin
+        l = ml(MeanPool((2,2)); insize = 3)
+        @test ismissing(neuron_value(l))
+    end
+
     @testset "ActivationContribution no grad" begin
         f(x) = 2 .* x .^ 2
         Flux.Zygote.@nograd f


### PR DESCRIPTION
At the same time made the method for computing neuron value from activation and gradients flexible.

Closes #54 

Fewer-examples-from-each-batch idea from #54 seemed to have less value, but it should be easy to add from the outside with these changes in place.