### PR TITLE
Updates for Flux 0.13

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NaiveNASflux"
 uuid = "85610aed-7d32-5e57-bb50-4c2e1c9e7997"
-version = "2.0.4"
+version = "2.0.5"
 
 [deps]
 Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
@@ -14,7 +14,7 @@ Setfield = "efcf1570-3423-57d1-acb7-fd33fddbac46"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-Flux = "0.12"
+Flux = "0.13"
 Functors = "0.2"
 JuMP = "0.19, 0.20, 0.21, 0.22, 0.23, 1"
 NaiveNASlib = "2"

--- a/src/NaiveNASflux.jl
+++ b/src/NaiveNASflux.jl
@@ -4,7 +4,7 @@ using Reexport
 @reexport using NaiveNASlib
 using NaiveNASlib.Extend, NaiveNASlib.Advanced
 import Flux
-using Flux: Dense, Conv, ConvTranspose, DepthwiseConv, CrossCor, LayerNorm, BatchNorm, InstanceNorm, GroupNorm, 
+using Flux: Dense, Conv, ConvTranspose, CrossCor, LayerNorm, BatchNorm, InstanceNorm, GroupNorm, 
             MaxPool, MeanPool, Dropout, AlphaDropout, GlobalMaxPool, GlobalMeanPool, cpu
 import Functors
 using Functors: @functor

--- a/src/mutable.jl
+++ b/src/mutable.jl
@@ -241,7 +241,7 @@ julia> lazy(ones(Float32, 2, 5)) |> size
 (3, 5)
 
 julia> layer(lazy)
-Dense(2, 3, relu)   # 9 parameters
+Dense(2 => 3, relu)  # 9 parameters
 ```
 """
 mutable struct LazyMutable <: AbstractMutableComp

--- a/src/select.jl
+++ b/src/select.jl
@@ -1,7 +1,7 @@
 
 select(pars::AbstractArray{T,N}, elements_per_dim...; newfun = randoutzeroin) where {T, N} = NaiveNASlib.parselect(pars, elements_per_dim...; newfun)
 select(::Missing, args...;kwargs...) = missing
-select(::Flux.Zeros, args...;kwargs...) = Flux.Zeros()
+select(s::Number, args...;kwargs...) = s
 
 struct WeightParam end
 struct BiasParam end
@@ -21,8 +21,8 @@ neuroninsert(lt::FluxParNorm, t::Val) = norminsert(lt, t)
 norminsert(::FluxParNorm, ::Union{Val{:β},Val{:μ}}) = (args...) -> 0
 norminsert(::FluxParNorm, ::Union{Val{:γ},Val{:σ²}}) = (args...) -> 1
 
-# Coupling between input and output weights make it difficult to do anything else?
-neuroninsert(::FluxDepthwiseConv, partype) = (args...) -> 0
+# Coupling between input and output weights when grouped make it difficult to do anything else?
+neuroninsert(lt::FluxConvolutional, partype) = ngroups(lt) == 1 ? randoutzeroin : (args...) -> 0
 
 randoutzeroin(T, d, s...) = _randoutzeroin(T,d,s)
 _randoutzeroin(T, d, s) = 0

--- a/src/types.jl
+++ b/src/types.jl
@@ -28,13 +28,19 @@ NaiveNASlib.shapetrait(::Flux.GRUCell) = FluxGru()
 
 abstract type FluxConvolutional{N} <: FluxParLayer end
 struct GenericFluxConvolutional{N} <: FluxConvolutional{N} end
-struct FluxConv{N} <: FluxConvolutional{N} end
-struct FluxConvTranspose{N}  <: FluxConvolutional{N} end
-struct FluxDepthwiseConv{N} <: FluxConvolutional{N}  end
+# Groups here is an eyesore. Its just to not have to tag a breaking version for Flux 0.13 due 
+# to some functions needing to tell the number of groups from the layertype alone
+struct FluxConv{N} <: FluxConvolutional{N} 
+    groups::Int
+end
+FluxConv{N}() where N = FluxConv{N}(1)
+struct FluxConvTranspose{N}  <: FluxConvolutional{N} 
+    groups::Int
+end
+FluxConvTranspose{N}() where N = FluxConvTranspose{N}(1)
 struct FluxCrossCor{N} <: FluxConvolutional{N}  end
-NaiveNASlib.shapetrait(::Conv{N}) where N = FluxConv{N}()
-NaiveNASlib.shapetrait(::ConvTranspose{N}) where N = FluxConvTranspose{N}()
-NaiveNASlib.shapetrait(::DepthwiseConv{N}) where N = FluxDepthwiseConv{N}()
+NaiveNASlib.shapetrait(l::Conv{N}) where N = FluxConv{N}(l.groups)
+NaiveNASlib.shapetrait(l::ConvTranspose{N}) where N = FluxConvTranspose{N}(l.groups)
 NaiveNASlib.shapetrait(::CrossCor{N}) where N = FluxCrossCor{N}()
 
 
@@ -42,14 +48,14 @@ abstract type FluxTransparentLayer <: FluxLayer end
 # Invariant layers with parameters, i.e nin == nout always and parameter selection must
 # be performed
 abstract type FluxParInvLayer <: FluxTransparentLayer end
-struct FluxDiagonal <: FluxParInvLayer end
+struct FluxScale <: FluxParInvLayer end
 struct FluxLayerNorm <: FluxParInvLayer end
 abstract type FluxParNorm <: FluxParInvLayer end
 struct FluxBatchNorm <: FluxParNorm end
 struct FluxInstanceNorm <: FluxParNorm end
 struct FluxGroupNorm <: FluxParNorm end
 
-NaiveNASlib.shapetrait(::Flux.Diagonal) = FluxDiagonal()
+NaiveNASlib.shapetrait(::Flux.Scale) = FluxScale()
 NaiveNASlib.shapetrait(::LayerNorm) = FluxLayerNorm()
 NaiveNASlib.shapetrait(::BatchNorm) = FluxBatchNorm()
 NaiveNASlib.shapetrait(::InstanceNorm) = FluxInstanceNorm()

--- a/src/util.jl
+++ b/src/util.jl
@@ -2,16 +2,15 @@ NaiveNASlib.nin(t::FluxLayer, l) = throw(ArgumentError("Not implemented for $t")
 NaiveNASlib.nout(t::FluxLayer, l) = throw(ArgumentError("Not implemented for $t"))
 
 NaiveNASlib.nin(::FluxParLayer, l) = [size(weights(l), indim(l))]
-NaiveNASlib.nout(::FluxParLayer, l) = size(weights(l), outdim(l))
-NaiveNASlib.nout(::FluxDepthwiseConv, l) = size(weights(l), outdim(l)) * nin(l)[]
 
-
+NaiveNASlib.nin(::FluxConvolutional, l) = [size(weights(l), indim(l)) * ngroups(l)]
 NaiveNASlib.nin(::FluxParInvLayer, l) = [nout(l)]
 
-NaiveNASlib.nout(::FluxDiagonal, l) = length(weights(l))
+NaiveNASlib.nout(::FluxParLayer, l) = size(weights(l), outdim(l))
+
+NaiveNASlib.nout(::FluxScale, l) = length(weights(l))
 NaiveNASlib.nout(::FluxParInvLayer, l::LayerNorm) = nout(l.diag)
 NaiveNASlib.nout(::FluxParNorm, l) = l.chs
-
 NaiveNASlib.nout(::FluxRecurrent, l) = div(size(weights(l), outdim(l)), outscale(l))
 
 outscale(l) = outscale(layertype(l))
@@ -34,10 +33,10 @@ outdim(::Flux2D) = 1
 actdim(::Flux2D) = 1
 actrank(::Flux2D) = 1
 
-indim(::FluxDiagonal) = 1
-outdim(::FluxDiagonal) = 1
-actdim(::FluxDiagonal) = 1
-actrank(::FluxDiagonal) = 1
+indim(::FluxScale) = 1
+outdim(::FluxScale) = 1
+actdim(::FluxScale) = 1
+actrank(::FluxScale) = 1
 
 indim(::FluxRecurrent) = 2
 outdim(::FluxRecurrent) = 1
@@ -50,7 +49,7 @@ actdim(::FluxConvolutional{N}) where N = 1+N
 actrank(::FluxConvolutional{N}) where N = 1+N
 indim(::Union{FluxConv{N}, FluxCrossCor{N}}) where N = 1+N
 outdim(::Union{FluxConv{N}, FluxCrossCor{N}}) where N = 2+N
-# Note: Absence of bias mean that bias is of type Flux.Zeros which mostly behaves like a normal array, mostly...
+# Note: Absence of bias mean that bias is a Bool (false), so beware!
 weights(l) = weights(layertype(l), l)
 bias(l) = bias(layertype(l), l)
 
@@ -60,8 +59,8 @@ bias(::FluxDense, l) = l.bias
 weights(::FluxConvolutional, l) = l.weight
 bias(::FluxConvolutional, l) = l.bias
 
-weights(::FluxDiagonal, l) = l.α
-bias(::FluxDiagonal, l) = l.β
+weights(::FluxScale, l) = l.scale
+bias(::FluxScale, l) = l.bias
 
 weights(lt::FluxRecurrent, l::Flux.Recur) = weights(lt, l.cell)
 bias(lt::FluxRecurrent, l::Flux.Recur) = bias(lt, l.cell)
@@ -80,3 +79,10 @@ hiddenstate(::FluxLstm, cell::Flux.LSTMCell) = [h for h in cell.state0]
 state(l) = state(layertype(l), l)
 state(::FluxRecurrent, l) = l.state
 state(::FluxLstm, l) = [h for h in l.state]
+
+ngroups(l) = ngroups(layertype(l), l)
+ngroups(lt, l) = 1
+ngroups(lt::FluxConvolutional, l) = ngroups(lt)
+ngroups(::FluxConvolutional) = 1
+ngroups(lt::FluxConv) = lt.groups
+ngroups(lt::FluxConvTranspose) = lt.groups

--- a/src/vertex.jl
+++ b/src/vertex.jl
@@ -204,7 +204,7 @@ Return the computation wrapped inside `v` and inside any mutable wrappers.
 julia> using NaiveNASflux, Flux
 
 julia> layer(fluxvertex(Dense(2,3), inputvertex("in", 2)))
-Dense(2, 3)         # 9 parameters
+Dense(2 => 3)         # 9 parameters
 ```
 """
 layer(v::AbstractVertex) = layer(base(v))
@@ -235,12 +235,12 @@ This typically means create a new layer with the given values and set the wrappe
 julia> v = fluxvertex(Dense(3, 4, relu), inputvertex("in", 3));
 
 julia> layer(v)
-Dense(3, 4, relu)   # 16 parameters
+Dense(3 => 4, relu)   # 16 parameters
 
 julia> NaiveNASflux.setlayer!(v, (;σ=tanh));
 
 julia> layer(v)
-Dense(3, 4, tanh)   # 16 parameters
+Dense(3 => 4, tanh)   # 16 parameters
 ```
 """
 function setlayer!(x, propval) end

--- a/src/vertex.jl
+++ b/src/vertex.jl
@@ -103,7 +103,7 @@ layertype(l::LayerTypeWrapper) = l.t
 Trait for computations for which a change in output size results in a change in input size but which 
 is not fully `SizeTransparent`.
 
-Example of this is DepthWiseConv where output size must be an integer multiple of the input size.
+Example of this is grouped convolutions where output size must be an integer multiple of the input size.
 
 Does not create any constraints or objectives, only signals that vertices after a 
 `SizeNinNoutConnected` might need to change size if the size of the `SizeNinNoutConnected` vertex changes.
@@ -147,7 +147,7 @@ fluxvertex(name::AbstractString, l, in::AbstractVertex; layerfun=LazyMutable, tr
 
 fluxvertex(::FluxParLayer, l, in::AbstractVertex, layerfun, traitfun) = absorbvertex(layerfun(MutableLayer(l)), in, traitdecoration = traitfun)
 
-fluxvertex(::FluxDepthwiseConv, l, in::AbstractVertex, layerfun, traitfun) = absorbvertex(layerfun(MutableLayer(l)), in; traitdecoration=traitfun ∘ SizeNinNoutConnected)
+fluxvertex(::FluxConvolutional, l, in::AbstractVertex, layerfun, traitfun) = absorbvertex(layerfun(MutableLayer(l)), in; traitdecoration= ngroups(l) == 1 ? traitfun : traitfun ∘ SizeNinNoutConnected)
 
 fluxvertex(::FluxParInvLayer, l, in::AbstractVertex, layerfun, traitfun) = invariantvertex(layerfun(MutableLayer(l)), in, traitdecoration=traitfun ∘ FixedSizeTrait)
 

--- a/src/vertex.jl
+++ b/src/vertex.jl
@@ -204,7 +204,7 @@ Return the computation wrapped inside `v` and inside any mutable wrappers.
 julia> using NaiveNASflux, Flux
 
 julia> layer(fluxvertex(Dense(2,3), inputvertex("in", 2)))
-Dense(2 => 3)         # 9 parameters
+Dense(2 => 3)       # 9 parameters
 ```
 """
 layer(v::AbstractVertex) = layer(base(v))
@@ -235,12 +235,12 @@ This typically means create a new layer with the given values and set the wrappe
 julia> v = fluxvertex(Dense(3, 4, relu), inputvertex("in", 3));
 
 julia> layer(v)
-Dense(3 => 4, relu)   # 16 parameters
+Dense(3 => 4, relu)  # 16 parameters
 
 julia> NaiveNASflux.setlayer!(v, (;σ=tanh));
 
 julia> layer(v)
-Dense(3 => 4, tanh)   # 16 parameters
+Dense(3 => 4, tanh)  # 16 parameters
 ```
 """
 function setlayer!(x, propval) end

--- a/test/mutable.jl
+++ b/test/mutable.jl
@@ -50,8 +50,8 @@
         end
 
         @testset "No bias" begin
-            m = MutableLayer(Dense(rand(3,2), Flux.Zeros()))
-            @test bias(layer(m)) == Flux.Zeros()
+            m = MutableLayer(Dense(rand(3,2), false))
+            @test bias(layer(m)) == false
 
             @test nin(m) == [2]
             @test nout(m) == 3
@@ -59,7 +59,7 @@
             inds = [2,3]
             Wexp = weights(layer(m))[inds, :]
             NaiveNASlib.Δsize!(m,_nins(m), inds)
-            assertlayer(layer(m), Wexp, Flux.Zeros())
+            assertlayer(layer(m), Wexp, false)
         end
     end
     @testset "Convolutional layers" begin
@@ -120,8 +120,8 @@
             end
 
             @testset "No bias" begin
-                m = MutableLayer(Conv(Flux.convfilter((2,3), 4=>5), Flux.Zeros()))
-                @test bias(layer(m)) == Flux.Zeros()
+                m = MutableLayer(Conv(Flux.convfilter((2,3), 4=>5), false))
+                @test bias(layer(m)) == false
 
                 @test nin(m) == [4]
                 @test nout(m) == 5
@@ -129,7 +129,7 @@
                 inds = [2,3]
                 Wexp = weights(layer(m))[:,:,:,inds]
                 NaiveNASlib.Δsize!(m, _nins(m), inds)
-                assertlayer(layer(m), Wexp, Flux.Zeros())
+                assertlayer(layer(m), Wexp, false)
             end
         end
 
@@ -162,7 +162,8 @@
                 wins = [1, 3]
                 wouts = [1, 2, 5, 6]
                 outputs = mapreduce(i -> wouts .+ (i-1) .* 6, vcat, wins)
-                Wexp, bexp = weights(m.layer)[:,:,wouts,wins], bias(m.layer)[outputs]
+                Wexp = reshape(reshape(weights(m.layer), 2, 2, 6, 3)[:,:,wouts,wins], 2, 2, 1, :)
+                bexp = bias(m.layer)[outputs]
                 NaiveNASlib.Δsize!(m, [wins], outputs)
                 assertlayer(m.layer, Wexp, bexp)
                 @test size(m(ones(Float32, 3,3,2,2)))[3:4] == (8, 2)
@@ -497,7 +498,8 @@
             wins = [1, 3]
             wouts = [1, 2, 5, 6]
             outs = mapreduce(i -> wouts .+ (i-1) .* 6, vcat, wins)
-            Wexp, bexp = weights(layer(m))[:,:,wouts,wins], bias(layer(m))[outs]
+            Wexp = reshape(reshape(weights(layer(m)), 2, 2, 6, 3)[:,:,wouts,wins], 2, 2, 1, :)
+            bexp = bias(layer(m))[outs]
 
             NaiveNASlib.Δsize!(m, [wins], outs)
             @test size(m(ones(Float32, 3,3,2,2)))[3:4] == (8, 2)

--- a/test/mutable.jl
+++ b/test/mutable.jl
@@ -198,8 +198,8 @@
         end
     end
 
-    @testset "Diagonal MutableLayer" begin
-        m = MutableLayer(Flux.Diagonal(4))
+    @testset "Scale MutableLayer" begin
+        m = MutableLayer(Flux.Scale(4))
 
         @test nin(m) == [nout(m)] == [4]
 

--- a/test/neuronutility.jl
+++ b/test/neuronutility.jl
@@ -50,7 +50,7 @@
     end
 
     @testset "Neuron utility Dense default no bias" begin
-        l = ml(Dense(ones(5, 3), Flux.Zeros()))
+        l = ml(Dense(ones(5, 3), false))
         @test size(neuronutility(l)) == (5,)
         @test neuronutility(l) ≈ neuronutility_safe(l)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,11 +3,8 @@ using NaiveNASlib.Advanced, NaiveNASlib.Extend
 
 function assertlayer(l, Wexp, bexp)
     @test size(Wexp) == size(weights(l))
-    if bexp isa Flux.Zeros
-        @test bias(l) isa Flux.Zeros
-    else
-        @test size(bexp) == size(bias(l))
-    end
+    @test size(bexp) == size(bias(l))
+    
     @test Wexp == weights(l)
     @test bexp == bias(l)
 end

--- a/test/util.jl
+++ b/test/util.jl
@@ -35,7 +35,7 @@
         @test nin(CrossCor((1,2,3), 4=>5)) == [4]
         @test nout(CrossCor((1,2,3), 4=>5)) == 5
 
-        @test nin(Flux.Diagonal(3)) == [nout(Flux.Diagonal(3))] == [3]
+        @test nin(Flux.Scale(3)) == [nout(Flux.Scale(3))] == [3]
 
         @test nin(LayerNorm(3)) == [nout(LayerNorm(3))] == [3]
         @test nin(BatchNorm(3)) == [nout(BatchNorm(3))] == [3]
@@ -61,7 +61,7 @@
         @test actdim(DepthwiseConv((1,2), 3=>6)) == 3
         @test actdim(CrossCor((1,2), 3=>6)) == 3
 
-        @test actdim(Flux.Diagonal(1)) == indim(Flux.Diagonal(2)) == outdim(Flux.Diagonal(3)) == 1
+        @test actdim(Flux.Scale(1)) == indim(Flux.Scale(2)) == outdim(Flux.Scale(3)) == 1
 
         @test actdim(GenericFluxRecurrent()) == 1
         @test actdim(RNN(3,4)) ==  1

--- a/test/util.jl
+++ b/test/util.jl
@@ -72,4 +72,12 @@
         @test_throws ArgumentError indim(BogusLayer())
         @test_throws ArgumentError outdim(BogusLayer())
     end
+
+    @testset "ngroups" begin
+        import NaiveNASflux: ngroups
+
+        @test ngroups(DepthwiseConv((2,), 3 => 9)) == ngroups(Conv((2,), 3 => 9; groups=3)) == ngroups(ConvTranspose((2,), 3 => 9; groups=3)) == 3
+        @test ngroups(Conv((3,3), 10 => 30; groups=5)) == ngroups(ConvTranspose((3,3), 10 => 30; groups=5)) == 5
+        @test ngroups(Conv((3,3), 10 => 30; groups=2)) == ngroups(ConvTranspose((3,3), 10 => 30; groups=2)) == 2
+    end 
 end

--- a/test/vertex.jl
+++ b/test/vertex.jl
@@ -154,7 +154,7 @@ end
             # just to check that I have understood the wiring of the weight
             @testset "4 inputs times 2" begin
                 inpt = inputvertex("in", 4, FluxConv{2}())
-                dc = fluxvertex("dc", DepthwiseConv(reshape(Float32[10 10 10 10;20 20 20 20], 1, 1, 2, 4), Float32[0,0,0,0,1,1,1,1]), inpt)
+                dc = fluxvertex("dc", DepthwiseConv(reshape(Float32[10 10 10 10;20 20 20 20], 1, 1, 4, 2), Float32[0,0,0,0,1,1,1,1]), inpt)
                 @test neuronutility(dc) == [20, 40, 20, 40, 21, 41, 21, 41]
                 @test reshape(dc(fill(1f0, (1,1,4,1))), :) == [10, 20, 10, 20, 11, 21, 11, 21]
                 @test Δnout!( dc => -4)
@@ -168,7 +168,7 @@ end
 
             @testset "2 inputs times 3" begin
                 inpt = inputvertex("in", 2, FluxConv{2}())
-                dc = fluxvertex("dc", DepthwiseConv(reshape(Float32[10 10;20 20;30 30], 1, 1, 3, 2), Float32[0,0,1,1,2,2]), inpt)
+                dc = fluxvertex("dc", DepthwiseConv(reshape(Float32[10 10;20 20;30 30], 1, 1, 2, 3), Float32[0,0,1,1,2,2]), inpt)
                 @test reshape(dc(fill(1f0, (1,1,2,1))), :) == [10, 20, 31, 11, 22, 32]
                 @test Δnout!(dc => -2)
                 @test lazyouts(dc) == [2,3,5,6] 
@@ -181,7 +181,7 @@ end
 
             @testset "1 input times 5" begin
                 inpt = inputvertex("in", 1, FluxConv{2}())
-                dc = fluxvertex("dc", DepthwiseConv(reshape(Float32.(10:10:50), 1, 1, 5, 1), Float32.(1:5)), inpt)
+                dc = fluxvertex("dc", DepthwiseConv(reshape(Float32.(10:10:50), 1, 1, 1, 5), Float32.(1:5)), inpt)
                 @test reshape(dc(fill(1f0, (1,1,1,1))), :) == [11, 22, 33, 44, 55]
                 @test Δnout!(dc=>-2)
                 @test lazyouts(dc) == 3:5 
@@ -194,7 +194,7 @@ end
 
             @testset "3 inputs times 7" begin
                 inpt = inputvertex("in", 3, FluxConv{2}())
-                dc = fluxvertex("dc", DepthwiseConv(reshape(repeat(Float32.(10:10:70), 3), 1,1,7,3), Float32.(1:21)), inpt)
+                dc = fluxvertex("dc", DepthwiseConv(reshape(repeat(Float32.(10:10:70), 3), 1,1,3,7), Float32.(1:21)), inpt)
                 @test reshape(dc(fill(10f0, (1,1,3,1))), :) == repeat(100:100:700, 3) .+ (1:21)
                 @test Δnout!(dc => -9) do v
                     v == dc || return 1
@@ -270,9 +270,9 @@ end
 
             # Test that we actually succeeded in making a valid model
             y1 = dc1(ones(Float32, 3,3, nout(inpt), 2))
-            @test size(y1, outdim(dc1)) == nout(dc1)
+            @test size(y1)[end-1] == nout(dc1)
             y2 = dc2(y1)
-            @test size(y2, outdim(dc2)) == nout(dc2)
+            @test size(y2)[end-1] == nout(dc2)
         end
 
         @testset "DepthwiseConv groupsize 3 into groupsize 5" begin
@@ -307,11 +307,11 @@ end
             
             # Test that we actually succeeded in making a valid model
             y1 = dc1(ones(Float32,5,5, nout(inpt), 2))
-            @test size(y1, outdim(dc1)) == nout(dc1)
+            @test size(y1)[end-1] == nout(dc1)
             y2 = dc2(y1)
-            @test size(y2, outdim(dc2)) == nout(dc2)
+            @test size(y2)[end-1] == nout(dc2)
             y3 = dc3(y2)
-            @test size(y3, outdim(dc3)) == nout(dc3)
+            @test size(y3)[end-1] == nout(dc3)
         end
 
         @testset "Depthwise conv change input size from Conv" begin

--- a/test/vertex.jl
+++ b/test/vertex.jl
@@ -212,35 +212,35 @@ end
                 @test reshape(dc(fill(10f0, (1,1,3,1))), :) == [101,303,404,505,0, 0, 108,310,411,512,0 ,0, 115,317,418,519,0, 0]
             end
 
-            @testset "DepthwiseConvAllowNinChangeStrategy" begin
-                import NaiveNASflux: DepthwiseConvAllowNinChangeStrategy
+            @testset "GroupedConvAllowNinChangeStrategy" begin
+                import NaiveNASflux: GroupedConvAllowNinChangeStrategy
                 import NaiveNASlib: ΔNout
                 inpt = inputvertex("in", 2, FluxConv{2}())
                 dc = fluxvertex("dc", DepthwiseConv((1,1), nout(inpt) => 3*nout(inpt)), inpt)
                 
                 # Get output multiplier == 4 (nout = 4 * nin) by adding one more outgroup (4 = 3 + 1)
-                okstrat = DepthwiseConvAllowNinChangeStrategy([1], [4], ΔNout(dc => 2))
+                okstrat = GroupedConvAllowNinChangeStrategy([1], [4], ΔNout(dc => 2))
                 @test Δsize!(okstrat, dc)
                 @test nout(dc) == 8
                 @test nin(dc) == [2]
 
-                failstrat = DepthwiseConvAllowNinChangeStrategy([10], [0], ΔNout(dc => 2))
+                failstrat = GroupedConvAllowNinChangeStrategy([10], [0], ΔNout(dc => 2))
                 @test @test_logs (:warn, r"Could not change nout of dc") match_mode=:any Δsize!(failstrat, dc) == false
             end
 
-            @testset "DepthwiseConvSimpleΔSizeStrategy" begin
-                using NaiveNASflux: DepthwiseConvSimpleΔSizeStrategy
+            @testset "GroupedConvSimpleΔSizeStrategy" begin
+                using NaiveNASflux: GroupedConvSimpleΔSizeStrategy
                 using NaiveNASlib: ΔNout
                 inpt = inputvertex("in", 2, FluxConv{2}())
                 dc = fluxvertex("dc", DepthwiseConv((1,1), nout(inpt) => 3*nout(inpt)), inpt)
                 
-                okstrat = DepthwiseConvSimpleΔSizeStrategy(4, ΔNout(dc => 2))
+                okstrat = GroupedConvSimpleΔSizeStrategy(4, ΔNout(dc => 2))
                 @test Δsize!(okstrat, dc)
                 @test nout(dc) == 8
                 @test nin(dc) == [2]
 
                 # We tested complete failure above, so lets make the relaxation work here
-                failstrat = DepthwiseConvSimpleΔSizeStrategy(5, ΔNout(dc => 3))
+                failstrat = GroupedConvSimpleΔSizeStrategy(5, ΔNout(dc => 3))
                 @test_logs (:warn, r"Could not change nout of dc") Δsize!(failstrat, dc)
                 @test nout(dc) == 10
                 @test nin(dc) == [2]


### PR DESCRIPTION
Mainly:
Partial handling of groups in Conv due to deprecation of DepthwiseConv
Flux.Diagonal => Flux.Scale