### PR TITLE
Set ActivationContribution from new params to eps

### DIFF
--- a/test/neuronutility.jl
+++ b/test/neuronutility.jl
@@ -78,9 +78,9 @@
         import NaiveNASflux: nograd
         f(x) = nograd(() -> 2 .* x .^ 2)
         l = ml(Dense(2,3), ActivationContribution)
-        @test neuronutility(l) == zeros(3)
+        @test neuronutility(l) == fill(eps(Float32), 3)
         tr(l, ones(Float32, 2, 1), loss = f ∘ Flux.mse)
-        @test neuronutility(l) == zeros(3)
+        @test neuronutility(l) == fill(eps(Float32), 3)
         @test length(params(l)) == length(params(layer(l)))
     end
 
@@ -93,12 +93,12 @@
         @test params(l) == params(layer(l))
         l2 = fmap(x -> x isa AbstractArray ? fill(17, size(x)) : x, l)
         @test unique(neuronutility(l2)) == unique(bias(layer(l2))) == unique(weights(layer(l2))) == [17]
-        @test neuronutility_org === neuronutility(l) == zeros(nout(l))
+        @test neuronutility_org === neuronutility(l) == fill(eps(Float32), nout(l))
     end
 
     @testset "Neuron utility Dense act contrib" begin
         l = ml(Dense(3,5), ActivationContribution)
-        @test neuronutility(l) == zeros(5)
+        @test neuronutility(l) == fill(eps(Float32), 5)
         tr(l, ones(Float32, 3, 4))
         @test size(neuronutility(l)) == (5,)
         @test length(params(l)) == length(params(layer(l)))
@@ -106,7 +106,7 @@
 
     @testset "Neuron utility Dense act contrib every 4" begin
         l = ml(Dense(3,5), l -> ActivationContribution(l, NeuronUtilityEvery(4)))
-        @test neuronutility(l) == zeros(5)
+        @test neuronutility(l) == fill(eps(Float32), 5)
         nvprev = copy(neuronutility(l))
         tr(l, ones(Float32, 3, 4))
         @test neuronutility(l) != nvprev
@@ -123,7 +123,7 @@
 
     @testset "Neuron utility RNN act contrib" begin
         l = ml(RNN(3,5), ActivationContribution)
-        @test neuronutility(l) == zeros(5)
+        @test neuronutility(l) == fill(eps(Float32), 5)
         tr(l, ones(Float32, 3, 8))
         @test size(neuronutility(l)) == (5,)
         @test length(params(l)) == length(params(layer(l)))
@@ -131,7 +131,7 @@
 
     @testset "Neuron utility Conv act contrib" begin
         l = ml(Conv((3,3), 2=>5, pad=(1,1)), ActivationContribution)
-        @test neuronutility(l) == zeros(5)
+        @test neuronutility(l) == fill(eps(Float32), 5)
         tr(l, ones(Float32, 4,4,2,5))
         @test size(neuronutility(l)) == (5,)
         @test length(params(l)) == length(params(layer(l)))


### PR DESCRIPTION
Seems like HiGHs is much more likely to remove parameters with 0 utility compared to CBC. This causes issues in the following cases
1) Tests where graphs are modified without having been trained first.
2) Situations when multiple mutations are applied before training. 

Here we use `eps(Float32)` as the initial utility. This is typically way below the tolerance but NaiveNASlib rescales utility so it seems to prevent the issue, at least for 1).