### PR TITLE
Functor2layer

### DIFF
--- a/src/NaiveNASflux.jl
+++ b/src/NaiveNASflux.jl
@@ -5,10 +5,9 @@ using Reexport
 using NaiveNASlib.Extend, NaiveNASlib.Advanced
 import Flux
 using Flux: Dense, Conv, ConvTranspose, CrossCor, LayerNorm, BatchNorm, InstanceNorm, GroupNorm, 
-            MaxPool, MeanPool, Dropout, AlphaDropout, GlobalMaxPool, GlobalMeanPool, cpu
+            MaxPool, MeanPool, Dropout, AlphaDropout, GlobalMaxPool, GlobalMeanPool, cpu, @layer
 import Optimisers
 import Functors
-using Functors: @functor
 using Statistics
 using Setfield: @set, setproperties
 using LinearAlgebra

--- a/src/mutable.jl
+++ b/src/mutable.jl
@@ -45,7 +45,7 @@ wrapped(m::MutableLayer) = m.layer
 layer(m::MutableLayer) = wrapped(m)
 layertype(m::MutableLayer) = layertype(layer(m))
 
-@functor MutableLayer
+@layer :expand MutableLayer
 
 
 function NaiveNASlib.Δsize!(m::MutableLayer, inputs::AbstractVector, outputs::AbstractVector; insert=neuroninsert, kwargs...) 
@@ -341,7 +341,7 @@ end
 layer(m::MutationTriggered) = layer(m.wrapped)
 layertype(m::MutationTriggered) = layertype(layer(m))
 
-@functor MutationTriggered
+@layer :expand MutationTriggered
 
 """
     ResetLazyMutable
@@ -366,7 +366,7 @@ end
 layer(m::ResetLazyMutable) = layer(m.wrapped)
 layertype(m::ResetLazyMutable) = layertype(layer(m))
 
-@functor ResetLazyMutable
+@layer :expand ResetLazyMutable
 
 """
     NoParams

--- a/src/neuronutility.jl
+++ b/src/neuronutility.jl
@@ -27,7 +27,7 @@ end
 ActivationContribution(l::AbstractMutableComp, method = Ewma(0.05f0)) = ActivationContribution(l, fill(eps(Float32), nout(l)), method)
 ActivationContribution(l, method = Ewma(0.05f0)) = ActivationContribution(l, Float32[], method)
 
-@functor ActivationContribution
+@layer :expand ActivationContribution
 
 wrapped(m::ActivationContribution) = m.layer
 

--- a/src/vertex.jl
+++ b/src/vertex.jl
@@ -10,7 +10,7 @@ struct InputShapeVertex{V<:AbstractVertex, L<:FluxLayer} <: AbstractVertex
     t::L
 end
 
-@functor InputShapeVertex
+@layer :expand InputShapeVertex
 
 const inputshapemotivation = """
 Providing the input type is not strictly necessary for the package to work and in many cases a normal `inputvertex` 

--- a/test/vertex.jl
+++ b/test/vertex.jl
@@ -330,7 +330,8 @@ end
             @test [nout(v2)] == nin(v3) == [8]
             @test lazyouts(v2) == [1, 2, 3, 4, 5, 6, -1, -1] 
 
-            @test graph(indata) == expout
+            # Approx here due to MAC OS CI getting differences in last decimals
+            @test graph(indata) ≈ expout
 
             @test Δnout!(v2 => -2) do v
                 v == v2 || return 1
@@ -340,7 +341,8 @@ end
             @test [nout(v2)] == nin(v3) == [6]
             @test lazyouts(v2) == 1:6
 
-            @test graph(indata) == expout
+            # Approx here due to MAC OS CI getting differences in last decimals
+            @test graph(indata) ≈ expout
 
             @test size(v2(ones(Float32, 1,1,nout(v1),1))) == (1,1,nin(v3)[],1)
         end
@@ -361,7 +363,8 @@ end
             @test [nout(v2)] == nin(v3) == [18]
             @test lazyouts(v2) == [1, 2, -1, -1, -1, -1, 3, 4, -1, -1, -1, -1, 5, 6, -1, -1, -1, -1] 
 
-            @test graph(indata) == expout
+            # Approx here due to MAC OS CI getting differences in last decimals
+            @test graph(indata) ≈ expout
 
             @test Δnout!(v2 => -6) do v
                 v == v2 || return 1
@@ -371,7 +374,8 @@ end
             @test [nout(v2)] == nin(v3) == [12]
             @test lazyouts(v2) ==  [1, 2, 3, 4, 7, 8, 9, 10, 13, 14, 15, 16]
 
-            @test graph(indata) == expout
+            # Approx here due to MAC OS CI getting differences in last decimals
+            @test graph(indata) ≈ expout
         end
     end
 

--- a/test/vertex.jl
+++ b/test/vertex.jl
@@ -420,7 +420,7 @@ end
             indata1 = reshape(collect(Float32, 1:nin1*4*4), 4, 4, nin1, 1)
             indata2 = reshape(collect(Float32, 1:nin2*4*4), 4, 4, nin2, 1)
 
-            convfun = (nin,nout) -> convtype((3,3), nin=>nout, pad = (1,1))
+            convfun = (nin,nout) -> convtype((3,3), nin=>nout, pad = 1)
             @test size(testgraph(convfun, nin1, nin2)(indata1, indata2)) == (4,4,9,1)
         end
 


### PR DESCRIPTION
Just removes some warnings due to Flux now recommending to use `@layer` instead of `@functor`. Unfortunately the recursive nature of  `CompGraph` is not compatible with the show stuff.